### PR TITLE
Bugfix - [PSAAS-24456] Disabled NIR data retrieval to prevent WHOIS RDAP lookup failures for Japanese/Korean IPs

### DIFF
--- a/release_notes/2.1.4.md
+++ b/release_notes/2.1.4.md
@@ -1,0 +1,1 @@
+* Added inc_nir=False parameter to the RDAP lookup method to reduce the number of HTTP requests sent to JPNIC/KRNIC Whois Gateways, preventing random failures caused by strict rate limiting on these services

--- a/release_notes/2.1.4.md
+++ b/release_notes/2.1.4.md
@@ -1,1 +1,0 @@
-* Added inc_nir=False parameter to the RDAP lookup method to reduce the number of HTTP requests sent to JPNIC/KRNIC Whois Gateways, preventing random failures caused by strict rate limiting on these services

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Added inc_nir=False parameter to the RDAP lookup method to reduce the number of HTTP requests sent to JPNIC/KRNIC Whois Gateways, preventing random failures caused by strict rate limiting on these services

--- a/whois_rdap_connector.py
+++ b/whois_rdap_connector.py
@@ -148,7 +148,7 @@ class WhoisRDAPConnector(BaseConnector):
                 obj_whois = IPWhois(ip, proxy_opener=opener)
             else:
                 obj_whois = IPWhois(ip)
-            whois_response = obj_whois.lookup_rdap()
+            whois_response = obj_whois.lookup_rdap(inc_nir=False)
             return phantom.APP_SUCCESS, whois_response
         except IPDefinedError as e_defined:
             self.error_print("Got IPDefinedError: ", e_defined)


### PR DESCRIPTION
### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->

**Cause:** WHOIS RDAP connector randomly fails for some Japanese IPs due to strict rate limiting on Japan’s Whois Gateway

**Fix:** Added the inc_nir=False parameter to the lookup_rdap() method, reducing the number of HTTP requests and avoiding rate limiting.


### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

No

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- I have verified that manual documentation has been updated where appropriate