### PR TITLE
Bugfix - [PSAAS-24456] Disabled NIR data retrieval to prevent WHOIS RDAP lookup failures for Japanese/Korean IPs

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,2 @@
 **Unreleased**
 * Added inc_nir=False parameter to the RDAP lookup method to reduce the number of HTTP requests sent to JPNIC/KRNIC Whois Gateways, preventing random failures caused by strict rate limiting on these services
-* this is a comment just to fix commit message


### PR DESCRIPTION
### Bug Fixes

This PR was created because the previous one failed due to incorrect commit message prefixes.
The changes have been moved to a new branch, and commit messages were updated to follow the required format.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />
No

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- I have verified that manual documentation has been updated where appropriate
