### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,2 @@
 **Unreleased**
-* Added inc_nir=False parameter to the RDAP lookup method to reduce the number of HTTP requests sent to JPNIC/KRNIC Whois Gateways, preventing random failures caused by strict rate limiting on these services
+* Added inc_nir=False parameter to the RDAP lookup method to reduce the number of HTTP requests sent to JPNIC/KRNIC Whois Gateways, preventing random failures caused by strict rate limiting on these services* Update Python version for 3.13

--- a/whois_rdap.json
+++ b/whois_rdap.json
@@ -16,7 +16,7 @@
     "latest_tested_versions": [
         "ipwhois-1.3.0"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "license": "Copyright (c) 2016-2025 Splunk Inc.",
     "logo": "logo_splunk.svg",
     "logo_dark": "logo_splunk_dark.svg",


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)